### PR TITLE
Fix the displaying of the title of the readme in github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#gulp-hologram
+# gulp-hologram
 
 [![NPM version][npm-image]][npm-url] [![Downloads][downloads-image]][npm-url]
 


### PR DESCRIPTION
Github follows the original specification for markdown headers strictly, they should have an space between the hash tag and the title themselves, this PR fixes this issue and makes the first impression of this gulp plugin better